### PR TITLE
Push Images To Harbor

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -61,7 +61,7 @@ pipeline {
                     }
                 }
                 stage('Deploy') {
-                    when { branch 'develop' }
+                    //when { branch 'main' }
                     environment {
                         DOCKER_HUB_CREDS = credentials('harbor-registry-token')
                     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,7 +3,7 @@ pipeline {
     triggers { cron('H H(0-2) * * 1') }
     environment {
         IMAGE_NAME = 'all-spark-base'
-        CONTAINER_REGISTRY  = 'registry.lsit.ucsb.edu'
+        CONTAINER_REGISTRY  = 'registry.cloud.college.ucsb.edu'
     }
     stages {
         stage('Build Test Deploy') {
@@ -61,7 +61,7 @@ pipeline {
                     }
                 }
                 stage('Deploy') {
-                    //when { branch 'main' }
+                    when { branch 'main' }
                     environment {
                         DOCKER_HUB_CREDS = credentials('harbor-registry-token')
                     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,6 +3,7 @@ pipeline {
     triggers { cron('H H(0-2) * * 1') }
     environment {
         IMAGE_NAME = 'all-spark-base'
+        CONTAINER_REGISTRY  = 'docker.io'
     }
     stages {
         stage('Build Test Deploy') {
@@ -60,14 +61,14 @@ pipeline {
                     }
                 }
                 stage('Deploy') {
-                    when { branch 'main' }
+                    when { branch 'develop' }
                     environment {
-                        DOCKER_HUB_CREDS = credentials('DockerHubToken')
+                        DOCKER_HUB_CREDS = credentials('harbor-registry-token')
                     }
                     steps {
                         container('podman') {
-                            sh 'skopeo copy containers-storage:localhost/$IMAGE_NAME docker://docker.io/ucsb/$IMAGE_NAME:latest --dest-username $DOCKER_HUB_CREDS_USR --dest-password $DOCKER_HUB_CREDS_PSW'
-                            sh 'skopeo copy containers-storage:localhost/$IMAGE_NAME docker://docker.io/ucsb/$IMAGE_NAME:v$(date "+%Y%m%d") --dest-username $DOCKER_HUB_CREDS_USR --dest-password $DOCKER_HUB_CREDS_PSW'
+                            sh 'skopeo copy containers-storage:localhost/$IMAGE_NAME docker://$CONTAINER_REGISTRY/ucsb/$IMAGE_NAME:latest --dest-username $DOCKER_HUB_CREDS_USR --dest-password $DOCKER_HUB_CREDS_PSW'
+                            sh 'skopeo copy containers-storage:localhost/$IMAGE_NAME docker://$CONTAINER_REGISTRY/ucsb/$IMAGE_NAME:v$(date "+%Y%m%d") --dest-username $DOCKER_HUB_CREDS_USR --dest-password $DOCKER_HUB_CREDS_PSW'
                         }
                     }
                     post {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,7 +3,7 @@ pipeline {
     triggers { cron('H H(0-2) * * 1') }
     environment {
         IMAGE_NAME = 'all-spark-base'
-        CONTAINER_REGISTRY  = 'docker.io'
+        CONTAINER_REGISTRY  = 'registry.lsit.ucsb.edu'
     }
     stages {
         stage('Build Test Deploy') {

--- a/README.md
+++ b/README.md
@@ -9,7 +9,10 @@ Looking for RStudio support?  Check out our [RStudio base image](https://hub.doc
 
 The most basic way to demo this locally: 
 
-`podman -it -p8888:8888 ucsb/all-spark-base:latest`
+```
+podman pull registry.cloud.college.ucsb.edu/ucsb/all-spark-base:latest
+podman -it -p8888:8888 ucsb/all-spark-base:latest
+```
 
 In the stdout, there will be a link that includes a token that will allow you to login locally with a browser.  Common endpoints are `/lab` and `/hub`.
 


### PR DESCRIPTION
We've been getting lots of failures while trying to push images to docker hub. Harbor is on prem and should increase build times and stability when pulling images as well. We'll still sync images to dockerhub, as there's a secondary background direction replication available, but this way we can get deployments done if dockerhub is still having a bad day. 


Verified that pulls from registry.cloud were working: 

```
$ podman pull registry.cloud.college.ucsb.edu/ucsb/all-spark-base:latest
Trying to pull registry.cloud.college.ucsb.edu/ucsb/all-spark-base:latest...
Getting image source signatures
Copying blob 698532ef335b skipped: already exists  
Copying blob d6fc234a08d9 skipped: already exists  
[...]
Copying config d042280669 done   | 
Writing manifest to image destination
d042280669362c51223be77ff0e15a74d9b9ea7024318c5ee645127ea308a1fb
```

<img width="942" height="668" alt="image" src="https://github.com/user-attachments/assets/4f57d229-bed2-4b13-8dd9-09b633edabaf" />
